### PR TITLE
Improvements and extension for Arduino Timer Library

### DIFF
--- a/ReadMe.txt
+++ b/ReadMe.txt
@@ -10,3 +10,13 @@ Changed data types of variables and functions:
  o added return values to Timer::pulse() and Timer::oscillate(uint8_t, unsigned long, uint8_t).
  o changed test in Event::update() to use subtraction to avoid rollover issues.
 Updated keywords.txt file to include all functions.
+
+1.2 by Damian Philipp
+ o Added a range check to Timer::stop() to avoid memory corruption.
+ o Added constants to <Timer.h>: 
+    - NO_TIMER_AVAILABLE: Signals that while an event was to be queued, no free timer could be found.
+    - TIMER_NOT_AN_EVENT: Can be used to flag a variable that *might* contain a timer ID as *not* containing a timer ID
+ o Replaced a bunch of magic numbers in <Timer.cpp> by the above constants
+ o Added several comments
+ o Added Timer::pulseImmediate(). pulseImmediate sets the pin to the specified value for the given
+   duration. After the duration, the pin is set to !value.

--- a/Timer.cpp
+++ b/Timer.cpp
@@ -60,7 +60,7 @@ int8_t Timer::after(unsigned long period, void (*callback)())
 int8_t Timer::oscillate(uint8_t pin, unsigned long period, uint8_t startingValue, int repeatCount)
 {
 	int8_t i = findFreeEventIndex();
-	if (i == -1) return -1;
+	if (i == NO_TIMER_AVAILABLE) return NO_TIMER_AVAILABLE;
 
 	_events[i].eventType = EVENT_OSCILLATE;
 	_events[i].pin = pin;
@@ -78,14 +78,35 @@ int8_t Timer::oscillate(uint8_t pin, unsigned long period, uint8_t startingValue
 	return oscillate(pin, period, startingValue, -1); // forever
 }
 
+/**
+ * This method will generate a pulse of !startingValue, occuring period after the
+ * call of this method and lasting for period. The Pin will be left in !startingValue.
+ */
 int8_t Timer::pulse(uint8_t pin, unsigned long period, uint8_t startingValue)
 {
 	return oscillate(pin, period, startingValue, 1); // once
 }
 
+/**
+ * This method will generate a pulse of startingValue, starting immediately and of
+ * length period. The pin will be left in the !startingValue state
+ */
+int8_t Timer::pulseImmediate(uint8_t pin, unsigned long period, uint8_t pulseValue)
+{
+	int8_t id(oscillate(pin, period, pulseValue, 1));
+	// now fix the repeat count
+	if (id >= 0 && id < MAX_NUMBER_OF_EVENTS) {
+		_events[id].repeatCount = 1;
+	}
+	return id;
+}
+
+
 void Timer::stop(int8_t id)
 {
-	_events[id].eventType = EVENT_NONE;
+	if (id >= 0 && id < MAX_NUMBER_OF_EVENTS) {
+		_events[id].eventType = EVENT_NONE;
+	}
 }
 
 void Timer::update(void)
@@ -108,5 +129,5 @@ int8_t Timer::findFreeEventIndex(void)
 			return i;
 		}
 	}
-	return -1;
+	return NO_TIMER_AVAILABLE;
 }

--- a/Timer.h
+++ b/Timer.h
@@ -26,7 +26,10 @@
 #include <inttypes.h>
 #include "Event.h"
 
-#define MAX_NUMBER_OF_EVENTS 10
+#define MAX_NUMBER_OF_EVENTS (10)
+
+#define TIMER_NOT_AN_EVENT (-2)
+#define NO_TIMER_AVAILABLE (-1)
 
 class Timer
 {
@@ -39,7 +42,18 @@ public:
   int8_t after(unsigned long duration, void (*callback)(void));
   int8_t oscillate(uint8_t pin, unsigned long period, uint8_t startingValue);
   int8_t oscillate(uint8_t pin, unsigned long period, uint8_t startingValue, int repeatCount);
+  
+  /**
+   * This method will generate a pulse of !startingValue, occuring period after the
+   * call of this method and lasting for period. The Pin will be left in !startingValue.
+   */
   int8_t pulse(uint8_t pin, unsigned long period, uint8_t startingValue);
+  
+  /**
+   * This method will generate a pulse of pulseValue, starting immediately and of
+   * length period. The pin will be left in the !pulseValue state
+   */
+  int8_t pulseImmediate(uint8_t pin, unsigned long period, uint8_t pulseValue);
   void stop(int8_t id);
   void update(void);
 

--- a/keywords.txt
+++ b/keywords.txt
@@ -17,6 +17,7 @@ every	KEYWORD2
 after	KEYWORD2
 oscillate	KEYWORD2
 pulse	KEYWORD2
+pulseImmediate KEYWORD2
 stop	KEYWORD2
 update	KEYWORD2
 findFreeEventIndex	KEYWORD2


### PR DESCRIPTION
 o Added a range check to Timer::stop() to avoid memory corruption.
 o Added constants to <Timer.h>:
    - NO_TIMER_AVAILABLE: Signals that while an event was to be queued, no free timer could be found.
    - TIMER_NOT_AN_EVENT: Can be used to flag a variable that _might_ contain a timer ID as _not_ containing a timer ID
 o Replaced a bunch of magic numbers in <Timer.cpp> by the above constants
 o Added several comments
 o Added Timer::pulseImmediate(). pulseImmediate sets the pin to the specified value for the given duration. After the duration, the pin is set to !value.
