### PR TITLE
Timer::stop returns TIMER_NOT_AN_EVENT when timer was stopped

### DIFF
--- a/Timer.cpp
+++ b/Timer.cpp
@@ -105,11 +105,14 @@ int8_t Timer::pulseImmediate(uint8_t pin, unsigned long period, uint8_t pulseVal
 }
 
 
-void Timer::stop(int8_t id)
+int8_t Timer::stop(int8_t id)
 {
 	if (id >= 0 && id < MAX_NUMBER_OF_EVENTS) {
 		_events[id].eventType = EVENT_NONE;
+		return TIMER_NOT_AN_EVENT;
 	}
+	
+	return id;
 }
 
 void Timer::update(void)

--- a/Timer.h
+++ b/Timer.h
@@ -54,7 +54,7 @@ public:
    * length period. The pin will be left in the !pulseValue state
    */
   int8_t pulseImmediate(uint8_t pin, unsigned long period, uint8_t pulseValue);
-  void stop(int8_t id);
+  int8_t stop(int8_t id);
   void update(void);
 
 protected:


### PR DESCRIPTION
When Timer::stop returns TIMER_NOT_AN_EVENT when a timer was stopped it is more easy to invalidate a timer ID variable. 
  tmr = t.stop(tmr);  

Otherwise some side effect may happen especially when you use more than one timer, e.g.:
  t1 = t.every(200, foo);
  t.stop(t1);
  ....
  t2 = t.every(100, bar);
  t.stop(t1);  // for some reason you call stop(t1) here again 

may result in stopping t2 if t1 is not invalidated
