### PR TITLE
Fixes cascading event creation issue. An event can now create new events...

### DIFF
--- a/Timer.cpp
+++ b/Timer.cpp
@@ -111,8 +111,14 @@ void Timer::stop(int8_t id)
 
 void Timer::update(void)
 {
-	unsigned long now = millis();
-	update(now);
+	for (int8_t i = 0; i < MAX_NUMBER_OF_EVENTS; i++)
+	{
+		if (_events[i].eventType != EVENT_NONE)
+		{
+			unsigned long now = millis();
+			_events[i].update(now);
+		}
+	}
 }
 
 void Timer::update(unsigned long now)


### PR DESCRIPTION
If an event callback generates another event:

```
Timer t;
void setup()
{
  addTimer();
}

void loop() {
  t.update();
}

void addTimer() {
  t.after (60000,fireEvent); 
}

void fireEvent() {
  t.after (60000, fireAnotherEvent);
} 

void fireAnotherEvent() {
  //
}
```

There is an issue with Timer::update that will cause the new event to be created with a lastEventTime that appears to be in the future. If the next update occurs very soon after, unsigned int math will created a huge elapsed time, causing the new event to timeout prematurely.

This patch "defectors" the Timer update method to reload millis between event updates. It preserves the ability to call update with a "frozen in time" millis.

Thanks for the updates!
