### PR TITLE
[v2.1 branch] Fix math to avoid integer overflow

### DIFF
--- a/examples/pin_high_10_mins/pin_high_10_mins.pde
+++ b/examples/pin_high_10_mins/pin_high_10_mins.pde
@@ -6,8 +6,8 @@ int pin = 13;
 void setup()
 {
   pinMode(pin, OUTPUT);
-  t.pulse(pin, 10 * 1000, HIGH); // 10 seconds
-  // t.pulse(pin, 10 * 60 * 1000, HIGH); // 10 minutes  
+  t.pulse(pin, 10 * 1000UL, HIGH); // 10 seconds
+  // t.pulse(pin, 10 * 60 * 1000UL, HIGH); // 10 minutes  
 }
 
 void loop()


### PR DESCRIPTION
Previously, the math in the commented line would result in a pulse of 10176 ms when compiled for architectures with 16 bit int, rather than the promised 10 minutes.