### PR TITLE
Use correct field separator in keywords.txt

### DIFF
--- a/keywords.txt
+++ b/keywords.txt
@@ -17,7 +17,7 @@ every	KEYWORD2
 after	KEYWORD2
 oscillate	KEYWORD2
 pulse	KEYWORD2
-pulseImmediate KEYWORD2
+pulseImmediate	KEYWORD2
 stop	KEYWORD2
 update	KEYWORD2
 findFreeEventIndex	KEYWORD2


### PR DESCRIPTION
The Arduino IDE requires the use of a single true tab separator between the keyword name and identifier. When spaces are used rather than a true tab the keyword is not highlighted.

Reference:
https://github.com/arduino/Arduino/wiki/Arduino-IDE-1.5:-Library-specification#keywords