### PR TITLE
Fix bug in event handling when comparing unsigned integers

### DIFF
--- a/Event.cpp
+++ b/Event.cpp
@@ -42,7 +42,8 @@ void Event::update(void)
 
 void Event::update(unsigned long now)
 {
-	if (now - lastEventTime >= period)
+	// attention: lastEventTime might be higher than now
+	if (now >= period + lastEventTime)
 	{
 		switch (eventType)
 		{


### PR DESCRIPTION
I had a problem with events being executed immediately instead of (correctly) after the given delay:

When `Timer.after(delay, callback)` is called during another callback call which takes more than one mili-second, then in the comparison in `Event.cpp` the value of `lastEventTime` is higher than `now`'s value because `now` was set before the beginning of the "outer" callback. So the difference between the unsigned integers `now - lastEventTime` is "negative" but the result will also be an unsigned. So `if (now - lastEventTime >= period)` will also be true.

This PR fixes this problem by a simple change in the comparison term.

I've tested the new code in my Environment and the problem is solved.