### PR TITLE
Added a reset() method to restart timers.

### DIFF
--- a/Event.cpp
+++ b/Event.cpp
@@ -63,3 +63,8 @@ void Event::update(unsigned long now)
 		eventType = EVENT_NONE;
 	}
 }
+
+void Event::reset() 
+{
+	lastEventTime = now;	
+}

--- a/Event.h
+++ b/Event.h
@@ -36,6 +36,7 @@ public:
   Event(void);
   void update(void);
   void update(unsigned long now);
+  void reset();
   int8_t eventType;
   unsigned long period;
   int repeatCount;

--- a/Timer.cpp
+++ b/Timer.cpp
@@ -125,6 +125,18 @@ void Timer::update(unsigned long now)
 		}
 	}
 }
+
+void Timer::reset() 
+{
+	for (int8_t i = 0; i < MAX_NUMBER_OF_EVENTS; i++)
+	{
+		if (_events[i].eventType != EVENT_NONE)
+		{
+			_events[i].reset();
+		}
+	}
+}
+
 int8_t Timer::findFreeEventIndex(void)
 {
 	for (int8_t i = 0; i < MAX_NUMBER_OF_EVENTS; i++)

--- a/Timer.h
+++ b/Timer.h
@@ -58,6 +58,12 @@ public:
   void update(void);
   void update(unsigned long now);
 
+  /**
+   * This method will reset all event timers. Use this to restart any timed events
+   * to start counting from now.
+   */ 
+  void reset();
+
 protected:
   Event _events[MAX_NUMBER_OF_EVENTS];
   int8_t findFreeEventIndex(void);


### PR DESCRIPTION
Hi Jack, I stumbled across another handy library of yours!

In this case I added a reset() method. I am using the timer to poll an external source in case there has been no activity for an interval. If there has been activity, I want to reset the timer to start counting again from the end of that activity. This seemed to neatest way to do it.

Thanks,
Tyson LT